### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,7 +12,7 @@ jobs:
       uses: actions/checkout@v2
       
     - name: Build and push Docker image in container registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: crfalcao.azurecr.io/money-tracker
         registry: ${{ secrets.AZ_DOCKER_REGISTRY }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore